### PR TITLE
Fix week progression when no events available

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3,12 +3,13 @@
 import chalk from 'chalk';
 import figlet from 'figlet';
 import inquirer from 'inquirer';
-import { 
-  initGame, 
-  getGameState, 
-  saveGame, 
+import {
+  initGame,
+  getGameState,
+  saveGame,
   loadGame,
-  GameStage
+  GameStage,
+  advanceWeek
 } from '../core/gameState';
 import {
   loadEvents,
@@ -101,17 +102,20 @@ const gameLoop = async () => {
       if (!currentEvent) {
         console.log(chalk.yellow('No available events for the current stage.'));
         console.log(chalk.yellow('Progressing to the next stage...'));
-        
+
         const nextStage = progressToNextStage();
         console.log(chalk.green(`\nYou've reached the ${nextStage} stage!`));
         console.log(chalk.green(getStageDescription(nextStage)));
-        
+
+        // Advance time since a week passes even without an event
+        advanceWeek();
+
         await inquirer.prompt({
           type: 'input',
           name: 'continue',
           message: 'Press ENTER to continue...'
         });
-        
+
         continue;
       }
     }


### PR DESCRIPTION
## Summary
- call `advanceWeek` when progressing stage without an event
- update imports

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687cee8489488332b822a2b7669e51c0