### PR TITLE
Add random global events and new acquisition paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Sandhill Road is a text-based survival strategy game inspired by Oregon Trail, b
 - Multiple game stages: Garage, Demo Day, Fundraising, PMF, Scaling, Crisis, Exit
 - Save/load game progress
 - 20+ unique narrative events
+- Occasional random events like market crashes or pandemics that shake up your strategy
 
 ## Installation
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -18,7 +18,8 @@ import {
   clearCurrentEvent,
   getCurrentEvent,
   getStageDescription,
-  progressToNextStage
+  progressToNextStage,
+  triggerRandomEvent
 } from '../core/narrativeEngine';
 
 // ASCII art banner
@@ -110,6 +111,12 @@ const gameLoop = async () => {
         // Advance time since a week passes even without an event
         advanceWeek();
 
+        const randomEvent = triggerRandomEvent();
+        if (randomEvent) {
+          console.log(chalk.magentaBright(`\n*** Random Event: ${randomEvent.title} ***`));
+          console.log(chalk.magenta(`${randomEvent.description}\n`));
+        }
+
         await inquirer.prompt({
           type: 'input',
           name: 'continue',
@@ -161,7 +168,13 @@ const gameLoop = async () => {
     const result = makeChoice(choice);
     
     console.log('\n' + chalk.yellow(result.resultText) + '\n');
-    
+
+    const randomEvent = triggerRandomEvent();
+    if (randomEvent) {
+      console.log(chalk.magentaBright(`\n*** Random Event: ${randomEvent.title} ***`));
+      console.log(chalk.magenta(`${randomEvent.description}\n`));
+    }
+
     await inquirer.prompt({
       type: 'input',
       name: 'continue',

--- a/src/data/events.json
+++ b/src/data/events.json
@@ -865,6 +865,86 @@
     "weight": 2
   },
   {
+    "id": "E022",
+    "title": "Acqui-hire Opportunity",
+    "description": "A larger company wants to acqui-hire your team for $5M, mostly for the talent.",
+    "choices": [
+      {
+        "id": "C001",
+        "text": "Take the deal",
+        "result": {
+          "companyStats.companyCash": 5000000,
+          "founderStats.morale": 3
+        },
+        "resultText": "Your product is shelved but the team is happy with generous packages.",
+        "nextEvent": "E030"
+      },
+      {
+        "id": "C002",
+        "text": "Negotiate for better terms",
+        "requires": {
+          "founderStats.hustle": 8
+        },
+        "result": {
+          "companyStats.companyCash": 8000000,
+          "founderStats.morale": 4
+        },
+        "resultText": "Your negotiation secures a better payout and partial control to keep building.",
+        "nextEvent": "E030"
+      },
+      {
+        "id": "C003",
+        "text": "Decline and push forward",
+        "result": {
+          "founderStats.morale": -1,
+          "companyStats.productProgress": 5
+        },
+        "resultText": "You double down on your vision and reject the acqui-hire offer."
+      }
+    ],
+    "stage": "Scaling",
+    "weight": 2
+  },
+  {
+    "id": "E023",
+    "title": "Bidding War",
+    "description": "Two industry giants want to acquire you, sparking a lucrative bidding war.",
+    "choices": [
+      {
+        "id": "C001",
+        "text": "Sell to highest bidder",
+        "result": {
+          "companyStats.companyCash": 50000000,
+          "founderStats.morale": 5
+        },
+        "resultText": "The fierce competition drives the price up and you close a massive deal.",
+        "nextEvent": "E030"
+      },
+      {
+        "id": "C002",
+        "text": "Choose the best partner",
+        "result": {
+          "companyStats.companyCash": 40000000,
+          "founderStats.morale": 4,
+          "companyStats.investorTrust": 2
+        },
+        "resultText": "You accept slightly less money in favor of the partner that shares your vision.",
+        "nextEvent": "E030"
+      },
+      {
+        "id": "C003",
+        "text": "Reject both offers",
+        "result": {
+          "companyStats.productProgress": 15,
+          "founderStats.stamina": -2
+        },
+        "resultText": "Investors are anxious but you decide to stay independent and keep growing."
+      }
+    ],
+    "stage": "Exit",
+    "weight": 2
+  },
+  {
     "id": "E030",
     "title": "Your Startup Journey Ends",
     "description": "You've successfully exited your startup. Looking back at the journey, what will you do with your new freedom and wealth?",
@@ -900,4 +980,4 @@
     "weight": 0,
     "repeatable": false
   }
-]    
+]

--- a/src/data/random-events.json
+++ b/src/data/random-events.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": "R001",
+    "title": "Global Market Crash",
+    "description": "A sudden market crash reduces customer spending and investor enthusiasm.",
+    "effect": {
+      "companyStats.revenue": -10000,
+      "companyStats.investorTrust": -2,
+      "founderStats.morale": -3
+    }
+  },
+  {
+    "id": "R002",
+    "title": "Pandemic Outbreak",
+    "description": "A global pandemic disrupts supply chains and forces your team to work remotely.",
+    "effect": {
+      "founderStats.stamina": -2,
+      "companyStats.productProgress": -5,
+      "companyStats.users": -100
+    }
+  },
+  {
+    "id": "R003",
+    "title": "Regional Conflict",
+    "description": "An unexpected war in a key market affects your expansion plans.",
+    "effect": {
+      "companyStats.revenue": -5000,
+      "companyStats.users": -50,
+      "founderStats.morale": -2
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- enable random global events with new event file
- add acqui-hire and bidding war events
- incorporate random events into game loop
- document randomness in README

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687d1a956c1c8332b00626e54d0afdf6